### PR TITLE
Improve README with project overview and tech stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,29 @@
-# Rocket Launches
+# Launch Monitor 🚀
 
+> **Never miss an upcoming launch.**
 
+Track upcoming rocket launches in real time, powered by live data from the Space Devs API.
 
-Uses an API to pull in data for upcoming launches. Built on Rails 8, styled with Tailwind CSS.
+🌐 **Live site:** [launch-monitor.fly.dev](https://launch-monitor.fly.dev/)
 
-API at https://thespacedevs.com/llapi
+---
 
-For testing purposes I will use this endpoint:
+## About
 
-https://lldev.thespacedevs.com/2.2.0/launch/upcoming/
+Launch Monitor pulls upcoming launch data from the [Space Devs API](https://thespacedevs.com/) and presents it in a clean, easy-to-browse interface. Whether you're a space enthusiast or just curious about what's launching next, this app keeps you in the loop.
+
+---
+
+## Built With
+
+| Technology | Version |
+|---|---|
+| [Ruby](https://www.ruby-lang.org/) | 3.4.9 |
+| [Ruby on Rails](https://rubyonrails.org/) | ~> 8.1 |
+| [SQLite](https://www.sqlite.org/) | ~> 2.9 |
+| [Tailwind CSS](https://tailwindcss.com/) | via tailwindcss-rails |
+| [HTTParty](https://github.com/jnunemaker/httparty) | ~> 0.24.2 |
+
+**HTTParty** is used to query the [Space Devs Launch Library 2 API](https://ll.thespacedevs.com/docs/).
+
+Deployed and hosted on [Fly.io](https://fly.io/).


### PR DESCRIPTION
## Summary

Updates the README to give the project a proper introduction and make it easy for visitors to understand what Launch Monitor is and how it's built.

## Changes

- Added tagline and project description
- Added link to the live site on Fly.io
- Added **Built With** table covering Ruby, Rails, SQLite, Tailwind CSS, and HTTParty
- Added a note about the Space Devs Launch Library 2 API integration