### PR TITLE
Render Launch Time in User's Timezone

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,3 @@
-//= link timezone.js
 //= link_tree ../images
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js

--- a/app/assets/javascripts/timezone.js
+++ b/app/assets/javascripts/timezone.js
@@ -1,5 +1,0 @@
-document.addEventListener("DOMContentLoaded", function() {
-  let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  document.cookie = "timezone=" + timezone;
-  console.log("Timezone cookie set to: " + timezone);
-})

--- a/app/helpers/launches_helper.rb
+++ b/app/helpers/launches_helper.rb
@@ -1,11 +1,2 @@
 module LaunchesHelper
-  def set_launch_date(launch_date)
-    date = Date.parse(launch_date)
-    date.strftime("%A, %b %-d")
-  end
-
-  def set_launch_time(launch_date)
-    time = Time.parse(launch_date).in_time_zone(Time.zone)
-    time.strftime("%l:%M%P")
-  end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -2,3 +2,5 @@
 import { application } from "controllers/application"
 import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
 eagerLoadControllersFrom("controllers", application)
+import localtimeController from "controllers/localtime_controller"
+application.register("localtime", localtimeController)

--- a/app/javascript/controllers/localtime_controller.js
+++ b/app/javascript/controllers/localtime_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    const iso = this.element.getAttribute("datetime")
+    const date = new Date(iso)
+
+    if (date) {
+      const launchDate = date.toLocaleString(undefined, {
+        weekday: "short", month: "short", day: "numeric",
+      })
+
+      const launchTime = date.toLocaleString(undefined, {
+        hour: "numeric", minute: "2-digit"
+      })
+
+    this.element.textContent = `${launchDate} - ${launchTime}`
+    }
+  }
+}

--- a/app/views/launches/index.html.erb
+++ b/app/views/launches/index.html.erb
@@ -1,5 +1,3 @@
-<%= javascript_include_tag 'timezone' %>
-
 <% @launchData.each do |launch| %>
   <div class="container mx-auto mb-16">
     <div class="flex flex-col" data-controller="expandable">
@@ -71,7 +69,12 @@
                 </div>
               </div>
               <p class="mt-3 mb-2"><b>Launch Agency:</b> <%= launch[:lsp] %></p>
-              <p class="my-2"><b>Launch Date: </b><%= set_launch_date(launch[:launch_date]) %> - <%= set_launch_time(launch[:launch_date]) %></p>
+              <p>
+                <b>Launch Date: </b> 
+                <time data-controller="localtime" datetime="<%= launch[:launch_date]  %>">
+                  <%= launch[:launch_date] %>
+                </time>
+              </p>
               <p class="my-2"><b>Status:</b> <%= launch[:status] %></p>
               <% if @hold_reason.present? %><p class="my-2"><b>Reason for hold:</b><%= @hold_reason %></p><% end %>
               <% if @fail_reason.present? %><p class="my-2"><b>Launch failure:</b><%= @fail_reason %></p><% end %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,3 +5,4 @@ Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
+Rails.application.config.assets.paths << Rails.root.join("app/assets/javascript")


### PR DESCRIPTION
This PR corrects deficiencies noted in [Issue #124](https://github.com/usmcamgrimm/LaunchMonitor/issues/124)

Deleted the timezoce cookie and added a Stimulus controller to properly set the timezone in the browser.

The addition of the Stimulus controller to properly format the date and time rendered the helper method and timezone cookie unnecessary, so I removed them, and removed from the config.
