### PR TITLE
Adjust column width so the rocket icons stay in line.

### DIFF
--- a/app/views/launches/_launch_card.html.erb
+++ b/app/views/launches/_launch_card.html.erb
@@ -34,7 +34,9 @@
             <div class="mt-4 transition-all duration-300 ease-in-out" data-expandable-target="content">
               <div class="mt-4 space-y-2">
                 <p class="my-2"><b>Payload:</b> <%= launch_card[:payload] %></p>
-                <p class="my-2"><b>Mission:</b> <%= launch_card[:mission] %></p>
+                <p class="my-2" style="width: 100%; max-width: 600px; display: block;">
+                  <b>Mission:</b> <%= launch_card[:mission] %>
+                </p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
The Mission description was pushing the edge of the column out to 808px, making the rocket icons jump. This sets a max-width so it stays responsive and keeps the icons in place"
